### PR TITLE
fix hungarian short formats

### DIFF
--- a/dist/globalize-runtime.js
+++ b/dist/globalize-runtime.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize Runtime v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize Runtime v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize-runtime/currency.js
+++ b/dist/globalize-runtime/currency.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize Runtime v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize Runtime v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize-runtime/date.js
+++ b/dist/globalize-runtime/date.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize Runtime v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize Runtime v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize-runtime/message.js
+++ b/dist/globalize-runtime/message.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize Runtime v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize Runtime v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize-runtime/number.js
+++ b/dist/globalize-runtime/number.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize Runtime v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize Runtime v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {
@@ -59,6 +59,56 @@ var validateParameterTypeNumber = function( value, name ) {
 		"Number"
 	);
 };
+
+
+
+
+/**
+ * EBNF representation:
+ *
+ * number_pattern_re =        prefix?
+ *                            padding?
+ *                            (integer_fraction_pattern | significant_pattern)
+ *                            scientific_notation?
+ *                            suffix?
+ *
+ * prefix =                   non_number_stuff
+ *
+ * padding =                  "*" regexp(.)
+ *
+ * integer_fraction_pattern = integer_pattern
+ *                            fraction_pattern?
+ *
+ * integer_pattern =          regexp([#,]*[0,]*0+)
+ *
+ * fraction_pattern =         "." regexp(0*[0-9]*#*)
+ *
+ * significant_pattern =      regexp([#,]*@+#*)
+ *
+ * scientific_notation =      regexp(E\+?0+)
+ *
+ * suffix =                   non_number_stuff
+ *
+ * non_number_stuff =         regexp(.*?)
+ *
+ *
+ * Regexp groups:
+ *
+ *  0: number_pattern_re
+ *  1: prefix
+ *  2: -
+ *  3: -
+ *  4: padding
+ *  5: (integer_fraction_pattern | significant_pattern)
+ *  6: integer_fraction_pattern
+ *  7: integer_pattern
+ *  8: fraction_pattern
+ *  9: significant_pattern
+ * 10: scientific_notation
+ * 11: suffix
+ * 12: -
+ */
+var numberCompactPatternRe = ( /^(('([^']|'')*'|[^*#@0,.E])*)(\*.)?((([#,]*[0,]*0+)(\.0*[0-9]*#*)?)|([#,]*@+#*))(E\+?0+)?(.*?)$/ );
 
 
 
@@ -384,7 +434,7 @@ var numberFormat = function( number, properties, pluralGenerator ) {
 				minimumFractionDigits, maximumFractionDigits, round, roundIncrement ) );
 			pluralForm = pluralGenerator ? pluralGenerator( rounded ) : "other";
 			compactPattern = compactMap[ "1" + zeroes + "-count-" + pluralForm ] || compactPattern;
-			compactProperties = compactPattern.match( numberPatternRe );
+			compactProperties = compactPattern.match( numberCompactPatternRe );
 
 			// update prefix/suffix with compact prefix/suffix
 			prefix += compactProperties[ 1 ];

--- a/dist/globalize-runtime/plural.js
+++ b/dist/globalize-runtime/plural.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize Runtime v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize Runtime v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize-runtime/relative-time.js
+++ b/dist/globalize-runtime/relative-time.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize Runtime v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize Runtime v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize-runtime/unit.js
+++ b/dist/globalize-runtime/unit.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize Runtime v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize Runtime v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize.js
+++ b/dist/globalize.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize/currency.js
+++ b/dist/globalize/currency.js
@@ -7,7 +7,7 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 (function( root, factory ) {
 

--- a/dist/globalize/date.js
+++ b/dist/globalize/date.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize/message.js
+++ b/dist/globalize/message.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize/number.js
+++ b/dist/globalize/number.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {
@@ -77,6 +77,56 @@ var validateParameterTypeString = function( value, name ) {
 		"a string"
 	);
 };
+
+
+
+
+/**
+ * EBNF representation:
+ *
+ * number_pattern_re =        prefix?
+ *                            padding?
+ *                            (integer_fraction_pattern | significant_pattern)
+ *                            scientific_notation?
+ *                            suffix?
+ *
+ * prefix =                   non_number_stuff
+ *
+ * padding =                  "*" regexp(.)
+ *
+ * integer_fraction_pattern = integer_pattern
+ *                            fraction_pattern?
+ *
+ * integer_pattern =          regexp([#,]*[0,]*0+)
+ *
+ * fraction_pattern =         "." regexp(0*[0-9]*#*)
+ *
+ * significant_pattern =      regexp([#,]*@+#*)
+ *
+ * scientific_notation =      regexp(E\+?0+)
+ *
+ * suffix =                   non_number_stuff
+ *
+ * non_number_stuff =         regexp(.*?)
+ *
+ *
+ * Regexp groups:
+ *
+ *  0: number_pattern_re
+ *  1: prefix
+ *  2: -
+ *  3: -
+ *  4: padding
+ *  5: (integer_fraction_pattern | significant_pattern)
+ *  6: integer_fraction_pattern
+ *  7: integer_pattern
+ *  8: fraction_pattern
+ *  9: significant_pattern
+ * 10: scientific_notation
+ * 11: suffix
+ * 12: -
+ */
+var numberCompactPatternRe = ( /^(('([^']|'')*'|[^*#@0,.E])*)(\*.)?((([#,]*[0,]*0+)(\.0*[0-9]*#*)?)|([#,]*@+#*))(E\+?0+)?(.*?)$/ );
 
 
 
@@ -402,7 +452,7 @@ var numberFormat = function( number, properties, pluralGenerator ) {
 				minimumFractionDigits, maximumFractionDigits, round, roundIncrement ) );
 			pluralForm = pluralGenerator ? pluralGenerator( rounded ) : "other";
 			compactPattern = compactMap[ "1" + zeroes + "-count-" + pluralForm ] || compactPattern;
-			compactProperties = compactPattern.match( numberPatternRe );
+			compactProperties = compactPattern.match( numberCompactPatternRe );
 
 			// update prefix/suffix with compact prefix/suffix
 			prefix += compactProperties[ 1 ];

--- a/dist/globalize/plural.js
+++ b/dist/globalize/plural.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize/relative-time.js
+++ b/dist/globalize/relative-time.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/globalize/unit.js
+++ b/dist/globalize/unit.js
@@ -7,10 +7,10 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 /*!
- * Globalize v1.2.2 2017-05-02T19:54Z Released under the MIT license
+ * Globalize v1.2.2 2017-05-05T17:52Z Released under the MIT license
  * http://git.io/TrdQbw
  */
 (function( root, factory ) {

--- a/dist/node-main.js
+++ b/dist/node-main.js
@@ -7,7 +7,7 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2017-05-02T19:54Z
+ * Date: 2017-05-05T17:52Z
  */
 
 // Core

--- a/src/number/compact-pattern-re.js
+++ b/src/number/compact-pattern-re.js
@@ -1,0 +1,50 @@
+define(function() {
+
+/**
+ * EBNF representation:
+ *
+ * number_pattern_re =        prefix?
+ *                            padding?
+ *                            (integer_fraction_pattern | significant_pattern)
+ *                            scientific_notation?
+ *                            suffix?
+ *
+ * prefix =                   non_number_stuff
+ *
+ * padding =                  "*" regexp(.)
+ *
+ * integer_fraction_pattern = integer_pattern
+ *                            fraction_pattern?
+ *
+ * integer_pattern =          regexp([#,]*[0,]*0+)
+ *
+ * fraction_pattern =         "." regexp(0*[0-9]*#*)
+ *
+ * significant_pattern =      regexp([#,]*@+#*)
+ *
+ * scientific_notation =      regexp(E\+?0+)
+ *
+ * suffix =                   non_number_stuff
+ *
+ * non_number_stuff =         regexp(.*?)
+ *
+ *
+ * Regexp groups:
+ *
+ *  0: number_pattern_re
+ *  1: prefix
+ *  2: -
+ *  3: -
+ *  4: padding
+ *  5: (integer_fraction_pattern | significant_pattern)
+ *  6: integer_fraction_pattern
+ *  7: integer_pattern
+ *  8: fraction_pattern
+ *  9: significant_pattern
+ * 10: scientific_notation
+ * 11: suffix
+ * 12: -
+ */
+return ( /^(('([^']|'')*'|[^*#@0,.E])*)(\*.)?((([#,]*[0,]*0+)(\.0*[0-9]*#*)?)|([#,]*@+#*))(E\+?0+)?(.*?)$/ );
+
+});

--- a/src/number/format.js
+++ b/src/number/format.js
@@ -1,11 +1,13 @@
 define([
+	"./compact-pattern-re",
 	"./format/grouping-separator",
 	"./format/integer-fraction-digits",
 	"./format/significant-digits",
 	"./pattern-re",
 	"../util/remove-literal-quotes"
-], function( numberFormatGroupingSeparator, numberFormatIntegerFractionDigits,
-	numberFormatSignificantDigits, numberPatternRe, removeLiteralQuotes ) {
+], function( numberCompactPatternRe, numberFormatGroupingSeparator,
+  numberFormatIntegerFractionDigits, numberFormatSignificantDigits, numberPatternRe,
+  removeLiteralQuotes ) {
 
 /**
  * format( number, properties )
@@ -84,7 +86,7 @@ return function( number, properties, pluralGenerator ) {
 				minimumFractionDigits, maximumFractionDigits, round, roundIncrement ) );
 			pluralForm = pluralGenerator ? pluralGenerator( rounded ) : "other";
 			compactPattern = compactMap[ "1" + zeroes + "-count-" + pluralForm ] || compactPattern;
-			compactProperties = compactPattern.match( numberPatternRe );
+			compactProperties = compactPattern.match( numberCompactPatternRe );
 
 			// update prefix/suffix with compact prefix/suffix
 			prefix += compactProperties[ 1 ];

--- a/test/unit/number/format.js
+++ b/test/unit/number/format.js
@@ -6,18 +6,19 @@ define([
 	"json!cldr-data/main/en/numbers.json",
 	"json!cldr-data/main/es/numbers.json",
 	"json!cldr-data/main/fa/numbers.json",
+	"json!cldr-data/main/hu/numbers.json",
 	"json!cldr-data/main/zh/numbers.json",
 	"json!cldr-data/supplemental/likelySubtags.json",
 	"json!cldr-data/supplemental/numberingSystems.json",
 
 	"cldr/event",
 	"cldr/supplemental"
-], function( Cldr, format, properties, arNumbers, enNumbers, esNumbers, faNumbers, zhNumbers,
+], function( Cldr, format, properties, arNumbers, enNumbers, esNumbers, faNumbers, huNumbers, zhNumbers,
 	likelySubtags, numberingSystems ) {
 
 // 1: Earth average diameter according to:
 // http://www.wolframalpha.com/input/?i=earth+diameter
-var ar, en, es, fa, zh,
+var ar, en, es, fa, hu, zh,
 	deci = 0.1,
 	earthDiameter = 12735, /* 1 */
 	pi = 3.14159265359;
@@ -27,6 +28,7 @@ Cldr.load(
 	enNumbers,
 	esNumbers,
 	faNumbers,
+	huNumbers,
 	zhNumbers,
 	likelySubtags,
 	numberingSystems
@@ -36,6 +38,7 @@ ar = new Cldr( "ar" );
 en = new Cldr( "en" );
 es = new Cldr( "es" );
 fa = new Cldr( "fa" );
+hu = new Cldr( "hu" );
 zh = new Cldr( "zh-u-nu-native" );
 
 QUnit.module( "Number Format" );
@@ -107,6 +110,14 @@ QUnit.test( "integers should format in compact mode", function( assert ) {
 	assert.equal( format( -1273500, properties( "#0", en, { compact: "long" } ) ), "-1 million" );
 	assert.equal( format( -1273500, properties( "#0;(#0)", en, { compact: "short" } ) ), "(1M)" );
 	assert.equal( format( -1273500, properties( "#0;(#0)", en, { compact: "long" } ) ), "(1 million)" );
+
+	// some hungarian short formats have a terminating E, which is treated as a special
+	// character in non-compact formats
+	// \u00A0 is a unicode non-breaking space
+	assert.equal( format( 1273, properties( "#0", hu, { compact: "short" } ) ), "1\u00A0E" );
+	assert.equal( format( 1273, properties( "#0", hu, { compact: "long" } ) ), "1 ezer" );
+	assert.equal( format(9000000, properties( "#0", hu, { compact: "short" } ) ), "9\u00A0M" );
+	assert.equal( format(9000000, properties( "#0", hu, { compact: "long" } ) ), "9 millió" );
 });
 
 QUnit.test( "decimals should format in compact mode", function( assert ) {


### PR DESCRIPTION
Some [hungarian short formats](https://github.com/unicode-cldr/cldr-numbers-full/blob/master/main/hu/numbers.json#L63-L68) end in the letter 'E'. This does not work with the [normal regex used to parse decimal formats](https://github.com/sieverk/globalize/blob/compact_number_dist_using_stable/src/number/pattern-re.js#L48), which interprets a [trailing E as a control character](http://www.unicode.org/reports/tr35/tr35-numbers.html#Number_Pattern_Character_Definitions) for exponents.

This branch adds a different regex for parsing compact number formats. Its only difference is that it does not look for control characters at the end of the string. My interpretation of the [compact numbers spec](http://www.unicode.org/reports/tr35/tr35-numbers.html#Compact_Number_Formats) says that this is ok, but there is some language ("The result is formatted according to the normal decimal pattern") that I'm not sure that I've correctly interpreted.